### PR TITLE
Fix: Use unwrap_or for optional fields in list_all_course function

### DIFF
--- a/examples/req_auth.rs
+++ b/examples/req_auth.rs
@@ -204,7 +204,7 @@ fn list_all_course(all_course: &Vec<Value>) {
             "Course id: {}, Course name: {}, Course teacher: {} {}",
             course["id"].as_str().unwrap().green().bold(),
             course["kcmc"].as_str().unwrap().purple().bold(),
-            course["dgjsmc"].as_str().unwrap().blue().bold(),
+            course["dgjsmc"].as_str().unwrap_or("").blue().bold(),
             course["tyxmmc"].as_str().unwrap_or("")
         )
     }


### PR DESCRIPTION
- Replaced `unwrap` with `unwrap_or` for optional fields in the `list_all_course` function.
- This change ensures that missing values are handled gracefully by providing default values.
